### PR TITLE
feat: Add support for custom SSL certificates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,6 +954,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
+]
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1225,7 +1234,7 @@ dependencies = [
 
 [[package]]
 name = "wasmedge_quickjs"
-version = "0.5.0-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "argparse",
  "chat-prompts",
@@ -1239,6 +1248,7 @@ dependencies = [
  "libc",
  "log",
  "rustls",
+ "rustls-pemfile",
  "tokio-rustls-wasi",
  "tokio_wasi",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ crypto-wasi = { version = "0.1.1", optional = true }
 chat-prompts = { version = "0.3", optional = true }
 wasi-nn = { git = "https://github.com/second-state/wasmedge-wasi-nn", branch = "ggml", optional = true }
 endpoints = { version = "0.2", optional = true }
+rustls-pemfile = "1.0.4"
 
 [features]
 default = ["tls"]

--- a/README.md
+++ b/README.md
@@ -13,3 +13,9 @@ cargo build --target wasm32-wasi --release
 wasmedge --dir .:. target/wasm32-wasi/release/wasmedge_quickjs.wasm example_js/hello.js WasmEdge Runtime
 Hello WasmEdge Runtime
 ```
+
+### Usage with custom ssl certs
+```bash
+$  wasmedge --dir .:. --dir /etc/ssl:/etc/ssl:readonly --env SSL_CERT_FILE="/etc/ssl/cert.pem" target/wasm32-wasi/release/wasmedge_quickjs.wasm example_js/wasi_https_fetch.js
+```
+substitute the value of `/etc/ssl` and `/etc/ssl/cert.pem` with the location of your cert folder and cert file

--- a/scripts/get_cert.sh
+++ b/scripts/get_cert.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Check if a domain is provided as an argument
+if [ -z "$1" ]; then
+    echo "Usage: $0 <domain>"
+    exit 1
+fi
+
+# Retrieve and print the combined TLS certificates
+openssl s_client -showcerts -connect "$1":443 2>/dev/null < /dev/null | awk '/BEGIN CERTIFICATE/,/END CERTIFICATE/{print}'

--- a/src/event_loop/certs.rs
+++ b/src/event_loop/certs.rs
@@ -1,0 +1,20 @@
+use std::{env, io};
+use std::fs::File;
+use std::io::BufReader;
+use rustls::Certificate;
+
+
+const ENV_CERT_FILE: &str = "SSL_CERT_FILE";
+
+pub fn load_certs_from_env() -> io::Result<Vec<Certificate>> {
+    let file_name = match env::var(ENV_CERT_FILE) {
+        Ok(val) => val,
+        Err(_) => {
+         return io::Result::Err(io::Error::from(io::ErrorKind::NotFound));
+        },
+    };
+    let file = File::open(file_name)?;
+    let mut reader = BufReader::new(file);
+    let mut certs = rustls_pemfile::certs(&mut reader)?;
+    Ok(certs.into_iter().map(Certificate).collect())
+}


### PR DESCRIPTION
wasmedge-quickjs doesnt support custom SSL support. Currently, wasmedge-quickjs uses `webpki_roots` to inject commonly used ssl certs without a way to customize. Without this PR, you cant call any HTTPS endpoints which has a cert that isnt supported by `webpki_roots` crate. Particulary, its important for companies with custom SSL certs.